### PR TITLE
Fix README code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Para mais segurança, o ideal é armazenar esse token usando um gerenciador de s
 ```hcl
 pm_api_token_id     = "terraform@pve!tf-token"
 pm_api_token_secret = "SEU_TOKEN_SECRETO"
+```
 
 5. **Permissões adequadas no Proxmox:**
    - Usuário com permissão para criar e gerenciar VMs/CTs.


### PR DESCRIPTION
## Summary
- properly close the Terraform snippet in `README.md`

## Testing
- `terraform -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fcfa62f88325b45cbba1141d0ddd